### PR TITLE
Add atome minimum amount and product whitelist

### DIFF
--- a/1.5/upload/admin/controller/payment/chip.php
+++ b/1.5/upload/admin/controller/payment/chip.php
@@ -332,6 +332,28 @@ class ControllerPaymentChip extends Controller {
 
     $this->data['webhook'] = HTTPS_CATALOG . 'index.php?route=payment/chip/callback';
 
+    if (isset($this->request->post['chip_payment_method_whitelist'])) {
+      $this->data['chip_payment_method_whitelist'] = $this->request->post['chip_payment_method_whitelist'];
+    } elseif ($this->config->get('chip_payment_method_whitelist')) {
+      $this->data['chip_payment_method_whitelist'] = $this->config->get('chip_payment_method_whitelist');
+    } else {
+      $this->data['chip_payment_method_whitelist'] = array();
+    }
+
+    $this->data['chip_available_payment_methods'] = ['fpx', 'fpx_b2b1', 'mastercard', 'maestro', 'visa', 'razer', 'razer_atome', 'razer_grabpay', 'razer_maybankqr', 'razer_shopeepay', 'razer_tng'];
+
+    if (isset($this->request->post['chip_atome_minimum'])) {
+      $this->data['chip_atome_minimum'] = $this->request->post['chip_atome_minimum'];
+    } else {
+      $this->data['chip_atome_minimum'] = $this->config->get('chip_atome_minimum');
+    }
+
+    if (isset($this->request->post['chip_atome_product_whitelist'])) {
+      $this->data['chip_atome_product_whitelist'] = $this->request->post['chip_atome_product_whitelist'];
+    } else {
+      $this->data['chip_atome_product_whitelist'] = $this->config->get('chip_atome_product_whitelist');
+    }
+
     $this->data['token'] = $this->session->data['token'];
 
     $this->template = 'payment/chip.tpl';

--- a/1.5/upload/admin/view/template/payment/chip.tpl
+++ b/1.5/upload/admin/view/template/payment/chip.tpl
@@ -74,10 +74,38 @@
                             </td>
                         </tr>
                         <tr>
-                        <td><?php echo $entry_general_public_key; ?></td>
-                        <td><textarea cols="50" rows="10" name="chip_general_public_key" readonly><?php echo $chip_general_public_key; ?></textarea>
-                        </td>
-                    </tr>
+                            <td><?php echo $entry_general_public_key; ?></td>
+                            <td><textarea cols="50" rows="10" name="chip_general_public_key" readonly><?php echo $chip_general_public_key; ?></textarea></td>
+                        </tr>
+                        <tr>
+                            <td>Payment Method Whitelist<br /><span class="help">This to control what payment method that will be available on payment page.</span></td>
+                            <td><div class="scrollbox">
+                                <?php $class = 'odd'; ?>
+                                <?php foreach ($chip_available_payment_methods as $payment_method) { ?>
+                                <?php $class = ($class == 'even' ? 'odd' : 'even'); ?>
+                                <div class="<?php echo $class; ?>">
+                                  <?php if (in_array($payment_method, $chip_payment_method_whitelist)) { ?>
+                                  <input type="checkbox" name="chip_payment_method_whitelist[]" value="<?php echo $payment_method; ?>" checked="checked" /><?php echo $payment_method; ?>
+                                  <?php } else { ?>
+                                  <input type="checkbox" name="chip_payment_method_whitelist[]" value="<?php echo $payment_method; ?>" /><?php echo $payment_method; ?>
+                                  <?php } ?>
+                                </div>
+                                <?php } ?>
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Atome Minimum Amount (Cent)<br /><span class="help">This to exclude Atome when total amount is less than specified amount. Only works when payment method whitelist is set.</span></td>
+                            <td>
+                                <input size="50" type="number" name="chip_atome_minimum" value="<?php echo $chip_atome_minimum; ?>"/>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Atome Product Whitelist<br /><span class="help">This to whitelist specific product ID for Atome. Separate product id with comma. Example: 1,2,3. Only works when payment method whitelist is set.</span></td>
+                            <td>
+                                <input size="50" type="text" name="chip_atome_product_whitelist" value="<?php echo $chip_atome_product_whitelist; ?>"/>
+                            </td>
+                        </tr>
                     </table>
                 </div>
 

--- a/1.5/upload/catalog/controller/payment/chip.php
+++ b/1.5/upload/catalog/controller/payment/chip.php
@@ -75,6 +75,37 @@ class ControllerPaymentChip extends Controller
       ),
     );
 
+    $payment_method_whitelist = $this->config->get('chip_payment_method_whitelist');
+    if (is_array($payment_method_whitelist) AND sizeof($payment_method_whitelist) > 0) {
+      $params['payment_method_whitelist'] = $payment_method_whitelist;
+
+      $atome_minimum_unparsed = $this->config->get('chip_atome_minimum');
+      $atome_minimum = preg_replace('/[^0-9]/', '', $atome_minimum_unparsed);
+      if (!empty($atome_minimum)) {
+        if ($params['purchase']['total_override'] < $atome_minimum) {
+          if ($atome_index_path = array_search('razer_atome', $params['payment_method_whitelist'])) {
+            unset($params['payment_method_whitelist'][$atome_index_path]);
+          }
+        }
+      }
+
+      if ($atome_product_whitelist_unparsed = $this->config->get('chip_atome_product_whitelist')) {
+        if (!empty($atome_product_whitelist_unparsed)) {
+          $atome_product_whitelist = explode (",", $atome_product_whitelist_unparsed);
+          if (!empty($atome_product_whitelist)) {
+            foreach ($products as $product) {
+              if (!in_array($product['product_id'], $atome_product_whitelist)) {
+                if ($atome_index_path = array_search('razer_atome', $params['payment_method_whitelist'])) {
+                  unset($params['payment_method_whitelist'][$atome_index_path]);
+                }
+              }
+            }
+          }
+        }
+      }
+      
+    }
+
     if ($this->config->get('chip_disable_success_redirect')) {
       unset($params['success_redirect']);
     }


### PR DESCRIPTION
## What does this change?
This add feature for OpenCart 1.5.x for:
1. Minimum amount for Atome.
1. Whitelist product id to be allowed payment with Atome.

## Asana / Jira / Trello task link

## How to test

1. Set payment method whitelist;
1. Set minimum amount;
1. Set product id whitelist;
1. Create order on the front end and ensure the condition satisfied the configuration.

## Images

<img width="1452" alt="Screenshot 2024-01-09 at 1 08 35 PM" src="https://github.com/CHIPAsia/chip-for-opencart/assets/19372567/7226cb65-3f2b-427c-84bc-bebc99a04b9c">

## PR Checklist:

-   [ ] Unit test provided?
-   [ ] All unit tests passed?
-   [ ] Deployed and tested in staging?
-   [ ] Project Management Solution (Asana / Jira / Trello) task link provided?
