### PR TITLE
Add duitnow_qr on payment_method_whitelist

### DIFF
--- a/1.5/upload/admin/controller/payment/chip.php
+++ b/1.5/upload/admin/controller/payment/chip.php
@@ -340,7 +340,7 @@ class ControllerPaymentChip extends Controller {
       $this->data['chip_payment_method_whitelist'] = array();
     }
 
-    $this->data['chip_available_payment_methods'] = ['fpx', 'fpx_b2b1', 'mastercard', 'maestro', 'visa', 'razer', 'razer_atome', 'razer_grabpay', 'razer_maybankqr', 'razer_shopeepay', 'razer_tng'];
+    $this->data['chip_available_payment_methods'] = ['fpx', 'fpx_b2b1', 'mastercard', 'maestro', 'visa', 'razer', 'razer_atome', 'razer_grabpay', 'razer_maybankqr', 'razer_shopeepay', 'razer_tng', 'duitnow_qr'];
 
     if (isset($this->request->post['chip_atome_minimum'])) {
       $this->data['chip_atome_minimum'] = $this->request->post['chip_atome_minimum'];


### PR DESCRIPTION
## What does this change?
This add ability for merchant to whitelist duitnow_qr as a payment method.

## Asana / Jira / Trello task link

## How to test
- Tick duitnow_qr on payment method whitelist setting
- Test if duitnow_qr option are available

## Images

<img width="1469" alt="Screenshot 2024-04-18 at 3 12 31 PM" src="https://github.com/CHIPAsia/chip-for-opencart/assets/19372567/af86aa13-04f6-4ecf-847e-0e481920822c">


## PR Checklist:

-   [ ] Unit test provided?
-   [ ] All unit tests passed?
-   [ ] Deployed and tested in staging?
-   [ ] Project Management Solution (Asana / Jira / Trello) task link provided?
